### PR TITLE
Fix for leading slashes in the current directory

### DIFF
--- a/msx/bank1/boot_menu.asm
+++ b/msx/bank1/boot_menu.asm
@@ -1318,12 +1318,50 @@ BM_PRINT_CUR_DIR:
     ld hl,BM_DOTS_BAR_S
     call PRINT
 
+    ; Skip leading slash in the last directory part, then print it
     call BM_GET_LAST_DIR_PNT
-    call PRINT
-    jr _BM_PRINT_CUR_DIR_END
+    jr _BM_PRINT_CUR_DIR_TRUNC
+
+    ;call BM_GET_LAST_DIR_PNT
+    ;call PRINT
+    ;jr _BM_PRINT_CUR_DIR_END
 
 _BM_PRINT_CUR_DIR_DIRECT:
     call BM_GET_CUR_DIR_ADD
+    ;call PRINT
+
+  ; Skip any leading '/'
+_BM_SKIP_LEADING_SLASH:
+    ld a,(hl)
+    cp "/"
+    jr nz,_BM_PRINT_CUR_DIR_PRINT
+    inc hl
+    jr _BM_SKIP_LEADING_SLASH
+
+_BM_PRINT_CUR_DIR_PRINT:
+    ld a,(hl)
+    or a
+    jr z,_BM_PRINT_CUR_DIR_END  ; If empty, done (just "/")
+
+    ; Print whatever is left
+    call PRINT
+    jr _BM_PRINT_CUR_DIR_END
+
+_BM_PRINT_CUR_DIR_TRUNC:
+    ; By default, BM_GET_LAST_DIR_PNT leaves HL pointing 
+    ; at the final name in the path, but let's skip slashes just in case
+
+_BM_SKIP_LEADING_SLASH_2:
+    ld a,(hl)
+    cp "/"
+    jr nz,_BM_PRINT_CUR_DIR_TRUNC_PRINT
+    inc hl
+    jr _BM_SKIP_LEADING_SLASH_2
+
+_BM_PRINT_CUR_DIR_TRUNC_PRINT:
+    ld a,(hl)
+    or a
+    jr z,_BM_PRINT_CUR_DIR_END  ; If empty, done (just "/.../")
     call PRINT
 
 _BM_PRINT_CUR_DIR_END:
@@ -1331,7 +1369,6 @@ _BM_PRINT_CUR_DIR_END:
     call CHPUT
     ld a,'K'
     jp CHPUT  ;Delete to end of line
-
 
 ;--- Get pointer to the last part of the current directory name
 ;    (assuming current dir is not root)
@@ -1833,7 +1870,7 @@ BM_RESETTING_S:
     db "Resetting computer...",0
 
 BM_DOTS_BAR_S:
-    db "/.../",0
+    db ".../",0
 
 BM_DOTDOT_S:
     db "..",0

--- a/msx/callbnk.asm
+++ b/msx/callbnk.asm
@@ -6,6 +6,13 @@
 ;
 ; Labels are defined at the main file, not here, so that this file can be included twice.
 
+; crisag - Key Changes:
+; - Bank switching now uses Konami SCC mapper addresses:
+;   5000h-57FFh for 4000h-5FFFh region
+;   7000h-77FFh for 6000h-7FFFh region
+; - Fixed banks 0 (0000h-3FFFh) and 2 (8000h-FFFFh) are assumed.
+; - Ensures correct switching before and after the routine call.
+
 ;CALL_IX:
     jp (ix)
 
@@ -17,11 +24,13 @@
 ; Output: All registers = output from the routine
 
 ;CALL_BANK:
-    push hl
-    ld hl,(7FFFh) ;L=Current bank
-    ex (sp),hl
-    push af
-    ld a,iyl
+    push hl     ; Save HL (used to track the current bank)
+    ld hl,(7FFFh)   ; Load the current bank number into HL (L=Current bank)
+    ex (sp),hl  ; Swap HL with the top of the stack (store previous bank)
+    push af     ; Save AF (to preserve flags)
+
+    ; Switch to the target bank
+    ld a,iyl    ; Load the target bank number into A
     if USE_ALTERNATIVE_PORTS=1
     or 80h
     endif


### PR DESCRIPTION
Hi Nestor, I converted your DiskROM to Konami SCC so it can work with the MSXUSB. During the process, I noticed that the code was adding unnecessary slashes to the current directory. To address this, I wrote a small routine to ensure that directories are printed with only a single leading slash. Just wanted to contribute and help out!