### PR TITLE
Add support for single sided disks and implement own XFER routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ Since version 2.1 using a USB floppy disk drive via an USB hub is supported. Som
 
 ## Compiling
 
-To compile this ROM you can use [Sjasm](https://github.com/Konamiman/sjasm). Adjust the configuration flags as desired in [the config.asm file](/msx/config.asm) and run:
-
-    sjasm rookiefdd.asm rookiefdd.rom
-
-Then flash `rookiefdd.rom` in your Rookie Drive and you're all set.
+To compile this ROM you need [Nestor80](https://github.com/Konamiman/Nestor80). Assemble the `rookiefdd.asm` file following the instructions in the header of [the file itself](/msx/rookiefdd.asm), then burn the generated `rookiefdd.rom` file in your Rookie Drive and you're all set.
 
 Alternatively, under Linux and WSL you can use the `build.sh` script to generate all the possible variants (with/without inverted CTRL key, disabling other kernels by default, and using the alternative Z80 ports) inside a `bin` directory.
 

--- a/msx/.gitignore
+++ b/msx/.gitignore
@@ -8,4 +8,5 @@ bin/
 temp.*
 *.bak
 bin/
-
+*.DSK
+*.dsk

--- a/msx/bank0/choice_strings.asm
+++ b/msx/bank0/choice_strings.asm
@@ -6,8 +6,10 @@
 ; but this string needs to be in bank 0.
 
 CHOICE_S:
-    db "1 - 720K, full format",13,10
-    db "2 - 720K, quick format",13,10
-    db "3 - 1.44M, full format",13,10
-    db "4 - 1.44M, quick format",13,10
+    db "1 - 360K, full format",13,10
+    db "2 - 360K, quick format",13,10
+    db "3 - 720K, full format",13,10
+    db "4 - 720K, quick format",13,10
+    db "5 - 1.44M, full format",13,10
+    db "6 - 1.44M, quick format",13,10
     db 0

--- a/msx/bank0/kernel.asm
+++ b/msx/bank0/kernel.asm
@@ -4314,13 +4314,13 @@ T570D:	defw	A40A7,A5445,A53A7,A546E,A5474,A5465,A5454,A5462
 	defw	A4720
 
 A576F:
-    if USE_ASCII8_ROM_MAPPER=1
+    if USE_ASCII8_ROM_MAPPER
     ld a,ROM_BANK_0*2+1
     ld (6800h),a    ;Set proper bank on second half of page 1
     ld (7000h),a    ;To prevent ROM from initializing again on page 2
     endif
 
-    if USE_ALTERNATIVE_PORTS=1
+    if USE_ALTERNATIVE_PORTS
     ld a,ROM_BANK_0+80h
     ld (ROM_BANK_SWITCH),a
     endif
@@ -4372,7 +4372,7 @@ A57D6:	ld	(hl),0C9H
 	ld	(XF365+0),a
 	ld	(XF365+1),hl		; read primairy slotregister entry
 	ld	a,006H
-    if INVERT_CTRL_KEY = 1
+    if INVERT_CTRL_KEY
     call    SNSMAT_AND_INVERT_CTRL
     else
 	call	SNSMAT
@@ -8646,7 +8646,7 @@ A7397:	call	XF36B			; enable ram on page 1
 ; Patches and moved code
 ; -----------------------------------------------------------------------------
 
-    if INVERT_CTRL_KEY = 1
+    if INVERT_CTRL_KEY
 SNSMAT_AND_INVERT_CTRL:
     call SNSMAT
     xor 2

--- a/msx/bank1/boot_menu.asm
+++ b/msx/bank1/boot_menu.asm
@@ -1277,7 +1277,7 @@ _BM_INVERT_CHARS_LOOP:
     add hl,de   ;HL = Pointer to start of char definition
 
     ld b,8
-_BM_INVERT_ONE_CHAR_LOOP
+_BM_INVERT_ONE_CHAR_LOOP:
     ld a,(hl)
     cpl
     out (c),a
@@ -1750,7 +1750,7 @@ BM_OPEN_INITIAL_DIR:
     xor a
     ret
 
-_BM_MAIN_GETDIR_ERR
+_BM_MAIN_GETDIR_ERR:
     ld hl,BM_ERROR_INITIAL_S
     call BM_PRINT_STATUS_WAIT_KEY
     ld a,1

--- a/msx/bank1/inihrd_inienv.asm
+++ b/msx/bank1/inihrd_inienv.asm
@@ -47,7 +47,7 @@ INIHRD_IMPL:
 
 INIENV_IMPL:
 
-    if WAIT_KEY_ON_INIT = 1
+    if WAIT_KEY_ON_INIT
     ld hl,INIHRD_NEXT
     push hl
     endif
@@ -55,7 +55,11 @@ INIENV_IMPL:
     xor a
     call WK_SET_LAST_REL_DRIVE
 
+    if USE_ROM_AS_DISK = 0
     call VERBOSE_RESET
+    endif
+    
+    ei
     ld b,30
     call DELAY_B
     call WK_GET_STORAGE_DEV_FLAGS

--- a/msx/bank1/misc.asm
+++ b/msx/bank1/misc.asm
@@ -56,6 +56,12 @@ _ASC_TO_ERR:
 ;			FF disk changed
 
 TEST_DISK:
+    if USE_ROM_AS_DISK
+    xor a
+    ld b,1
+    ret
+    endif
+
     call _RUN_TEST_UNIT_READY
     ret c
 

--- a/msx/bank1/verbose_reset.asm
+++ b/msx/bank1/verbose_reset.asm
@@ -70,51 +70,6 @@ _HW_RESET_TRY_OK:
     ld hl,NODEV_S
     jp z,PRINT
 
-    ;Experiments with hubs, please ignore
-    if 0
-
-    ld hl,HUB_FOUND_S
-    call PRINT
-    ld a,2
-    call HW_SET_ADDRESS
-    ld a,2
-    ld b,1
-    call HW_SET_CONFIG
-    ld hl,CMD_PORT_POWER
-    ld de,0
-    ld a,2
-    ld b,64
-    call HW_CONTROL_TRANSFER
-    add "0"
-    call CHPUT
-    ld hl,CMD_PORT_RESET
-    ld de,0
-    ld a,2
-    ld b,64
-    call HW_CONTROL_TRANSFER
-    add "0"
-    call CHPUT
-
-    halt
-    halt
-    halt
-    halt
-    halt
-
-    xor a
-    call HW_GET_DEV_DESCR
-    add "0"
-    call CHPUT
-    jr HUBDONE
-
-CMD_PORT_POWER:
-    db  00100011b, 3, 8, 0, 1, 0, 0, 0
-CMD_PORT_RESET:
-    db  00100011b, 3, 4, 0, 1, 0, 0, 0
-HUBDONE:
-
-    endif
-
     ld b,5
 _TRY_USB_INIT_DEV:
     push bc
@@ -144,7 +99,7 @@ _TRY_USB_INIT_DEV_OK:
     call PRINT
     jp PRINT_DEVICE_INFO
 
-    if WAIT_KEY_ON_INIT = 1
+    if WAIT_KEY_ON_INIT
 INIHRD_NEXT:
     jp CHGET
     endif
@@ -283,9 +238,13 @@ PRINT_ERROR:
 
 ROOKIE_S:
 	db "Rookie Drive NestorBIOS v2.1",13,10
-	db "(c) Konamiman 2018-2022",13,10
+	db "(c) Konamiman 2025",13,10
 	db 13,10
+    if USE_ROM_AS_DISK
+    db "Running in ROM disk mode",13
+    else
     db "Initializing device...",13
+    endif
 	db 0
 
 NOHARD_S:

--- a/msx/bank1/work_area.asm
+++ b/msx/bank1/work_area.asm
@@ -14,6 +14,8 @@
 ; +4: Bits 0-3: Last relative drive accessed
 ;     Bits 4-7: Misc flags
 ;               0: set if USB hub found
+;               1: set if force 1DD mode active
+;               2: set if force 2DD mode active
 ; +5: Last USB error (for CALL USBERROR)
 ; +6: Last ASC (for CALL USBERROR)
 ; +7: Last ASCQ (for CALL USBERROR)
@@ -31,7 +33,8 @@
 ;  01 = 16 bytes
 ;  10 = 32 bytes
 ;  11 = 64 bytes
-;
+
+
 ; Work area definition when a storage device is connected:
 ;
 ; +0: flags:

--- a/msx/build.sh
+++ b/msx/build.sh
@@ -1,10 +1,11 @@
 VERSION=2.1
 SRC_PATH=$(dirname "$0")
 SRC_FILE=${SRC_PATH}/rookiefdd.asm
-BASE_DEST_FILE=${SRC_PATH}/bin/rookiefdd${VERSION}
+DEST_DIR=${SRC_PATH}/bin
+BASE_DEST_FILE=${DEST_DIR}/rookiefdd${VERSION}
 N80_ARGS="--direct-output-write"
 
-mkdir -p $BIN_PATH
+mkdir -p $DEST_DIR
 
 echo RookieDrive FDD ROM version $VERSION
 echo

--- a/msx/build.sh
+++ b/msx/build.sh
@@ -1,43 +1,19 @@
 VERSION=2.1
 SRC_PATH=$(dirname "$0")
-BIN_PATH=$SRC_PATH/bin
+SRC_FILE=${SRC_PATH}/rookiefdd.asm
+BASE_DEST_FILE=${SRC_PATH}/bin/rookiefdd${VERSION}
+N80_ARGS="--direct-output-write"
 
 mkdir -p $BIN_PATH
 
 echo RookieDrive FDD ROM version $VERSION
 echo
 
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_normal.rom
-
-cp $SRC_PATH/rookiefdd.asm $SRC_PATH/rookiefdd.bak 
-sed -i 's/"config.asm"/"temp.asm"/g' $SRC_PATH/rookiefdd.asm
-
-sed 's/INVERT_CTRL_KEY: equ 0/INVERT_CTRL_KEY: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_inverted_ctrl.rom
-
-sed 's/DISABLE_OTHERS_BY_DEFAULT: equ 0/DISABLE_OTHERS_BY_DEFAULT: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_exclusive.rom
-
-sed 's/USE_ALTERNATIVE_PORTS: equ 0/USE_ALTERNATIVE_PORTS: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_alt_ports.rom
-
-sed 's/INVERT_CTRL_KEY: equ 0/INVERT_CTRL_KEY: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sed -i 's/DISABLE_OTHERS_BY_DEFAULT: equ 0/DISABLE_OTHERS_BY_DEFAULT: equ 1/g' $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_exclusive_inverted_ctrl.rom
-
-sed 's/INVERT_CTRL_KEY: equ 0/INVERT_CTRL_KEY: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sed -i 's/USE_ALTERNATIVE_PORTS: equ 0/USE_ALTERNATIVE_PORTS: equ 1/g' $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_alt_ports_inverted_ctrl.rom
-
-sed 's/DISABLE_OTHERS_BY_DEFAULT: equ 0/DISABLE_OTHERS_BY_DEFAULT: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sed -i 's/USE_ALTERNATIVE_PORTS: equ 0/USE_ALTERNATIVE_PORTS: equ 1/g' $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_alt_ports_exclusive.rom
-
-sed 's/INVERT_CTRL_KEY: equ 0/INVERT_CTRL_KEY: equ 1/g' $SRC_PATH/config.asm > $SRC_PATH/temp.asm
-sed -i 's/DISABLE_OTHERS_BY_DEFAULT: equ 0/DISABLE_OTHERS_BY_DEFAULT: equ 1/g' $SRC_PATH/temp.asm
-sed -i 's/USE_ALTERNATIVE_PORTS: equ 0/USE_ALTERNATIVE_PORTS: equ 1/g' $SRC_PATH/temp.asm
-sjasm $SRC_PATH/rookiefdd.asm $BIN_PATH/rookiefdd${VERSION}_alt_ports_exclusive_inverted_ctrl.rom
-
-cp $SRC_PATH/rookiefdd.bak $SRC_PATH/rookiefdd.asm
-rm $SRC_PATH/rookiefdd.bak
-rm $SRC_PATH/temp.*
+N80 $SRC_FILE ${BASE_DEST_FILE}_normal.rom $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_inverted_ctrl.rom -ds INVERT_CTRL_KEY $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_exclusive.rom -ds DISABLE_OTHERS_BY_DEFAULT $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_alt_ports.rom -ds USE_ALTERNATIVE_PORTS $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_exclusive_inverted_ctrl.rom -ds INVERT_CTRL_KEY,DISABLE_OTHERS_BY_DEFAULT $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_alt_ports_inverted_ctrl.rom -ds USE_ALTERNATIVE_PORTS,INVERT_CTRL_KEY $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_alt_ports_exclusive.rom -ds USE_ALTERNATIVE_PORTS,DISABLE_OTHERS_BY_DEFAULT $N80_ARGS
+N80 $SRC_FILE ${BASE_DEST_FILE}_alt_ports_exclusive_inverted_ctrl.rom -ds USE_ALTERNATIVE_PORTS,DISABLE_OTHERS_BY_DEFAULT,INVERT_CTRL_KEY $N80_ARGS

--- a/msx/callbnk.asm
+++ b/msx/callbnk.asm
@@ -22,10 +22,10 @@
     ex (sp),hl
     push af
     ld a,iyl
-    if USE_ALTERNATIVE_PORTS=1
+    if USE_ALTERNATIVE_PORTS
     or 80h
     endif
-    if USE_ASCII8_ROM_MAPPER=1
+    if USE_ASCII8_ROM_MAPPER
     sla a
     ld (ROM_BANK_SWITCH),a
     inc a
@@ -38,10 +38,10 @@
     ex (sp),hl  ;L=Previous bank
     push af
     ld a,l
-    if USE_ALTERNATIVE_PORTS=1
+    if USE_ALTERNATIVE_PORTS
     or 80h
     endif
-    if USE_ASCII8_ROM_MAPPER=1
+    if USE_ASCII8_ROM_MAPPER
     sla a
     ld (ROM_BANK_SWITCH),a
     inc a

--- a/msx/config.asm
+++ b/msx/config.asm
@@ -2,7 +2,29 @@
 ; By Konamiman, 2018
 ;
 ; This is the customization options file.
-; Flags are enabled with value 1 or disabled with value 0.
+; Flags are disabled when the value is 0 and enabled with any other value.
+; For debugging purposes you may make temporary changes directly to this file,
+; but a cleaner approach is to use the --define-symbols argument
+; when running Nestor80 (see rookiefdd.asm for an example).
+
+
+; -----------------------------------------------------------------------------
+; Configuration constant definition macro
+; -----------------------------------------------------------------------------
+
+; This macro defines a configuration flag/value if it hasn't been defined yet,
+; so the value will be the one defined here by default, but it can be overridden
+; by passing a --define-symbols argument to Nestor80.
+
+config_const: macro name,value
+    ifndef name
+        ifb <value>
+name: defl 0
+        else
+name: defl value
+        endif
+    endif
+endm
 
 
 ; -----------------------------------------------------------------------------
@@ -12,24 +34,25 @@
 ;Invert the behavior of the CTRL flag, so that
 ;the second "ghost" drive exists only if CTRL is pressed at boot time
 ;(this won't apply to the internal disk drive or other MSX-DOS kernels)
-INVERT_CTRL_KEY: equ 0
+config_const INVERT_CTRL_KEY
 
 ;When this flag is disabled, pressing SHIFT at boot time will disable
 ;all other MSX-DOS ROMs but not this one.
 ;When enabled, all other MSX-DOS ROMs will be disabled except if
 ;GRAPH is pressed at boot time.
-DISABLE_OTHERS_BY_DEFAULT: equ 0
+config_const DISABLE_OTHERS_BY_DEFAULT
 
 ;Use the alternative set of Z80 ports for accessing the CH376,
 ;if you want to use two Rookie Drives in the same computer
 ;one of them must use the normal ports and the other one
 ;must use the alternative ports
-USE_ALTERNATIVE_PORTS: equ 0
+config_const USE_ALTERNATIVE_PORTS
 
 ;Implement the "panic button":
 ;pressing CAPS+ESC will abort the current USB operation
 ;and reset the device
-IMPLEMENT_PANIC_BUTTON: equ 1
+config_const IMPLEMENT_PANIC_BUTTON,1
+
 
 ; -----------------------------------------------------------------------------
 ; Debugging switches
@@ -38,18 +61,24 @@ IMPLEMENT_PANIC_BUTTON: equ 1
 
 ;Enable this if you are Konamiman and you are using NestorMSX with
 ;the almigthy Arduino board that Xavirompe sent you 
-USING_ARDUINO_BOARD: equ 0
+config_const USING_ARDUINO_BOARD
 
 ;Enable to debug DSKIO calls: whenever DSKIO is called, text mode is enabled,
 ;the input parameters are printed, and system stops waiting for a key press
-DEBUG_DSKIO: equ 0
+config_const DEBUG_DSKIO
 
 ;Enable to wait for a key press after displaying the device information
 ;at boot time
-WAIT_KEY_ON_INIT: equ 0
+config_const WAIT_KEY_ON_INIT
 
 ;Enable to simulate a fake storage device connected to a USB port
-USE_FAKE_STORAGE_DEVICE: equ 0
+config_const USE_FAKE_STORAGE_DEVICE
+
+;Enable this to use a disk image file simulating a real floppy disk drive.
+;If this is enabled, the path of the disk image file needs to be set
+;in rookiefdd.asm, right after the "if USE_ROM_AS_DISK".
+;Also if this is enabled then the only supported mapper is ASCII 8.
+config_const USE_ROM_AS_DISK
 
 
 ; -----------------------------------------------------------------------------
@@ -57,17 +86,18 @@ USE_FAKE_STORAGE_DEVICE: equ 0
 ; -----------------------------------------------------------------------------
 
 ;The address to switch the ROM bank in the DOS2 mapper implemented by Rookie Drive
-ROM_BANK_SWITCH: equ 6000h
+config_const ROM_BANK_SWITCH,6000h
 
 ;Enable this if you are adapting this BIOS for hardware other than Rookie Drive
 ;and that hardware uses ASCII8 for ROM mapping.
 ;If you use any ROM mapper other than ASCII8 or DOS2 you will need to change
 ;the code, search usages of ROM_BANK_SWITCH for that.
-USE_ASCII8_ROM_MAPPER: equ 0
+config_const USE_ASCII8_ROM_MAPPER
 
 ;The ROM banks where all the code lives.
 ;You will need to change this only if you plan to somehow integrate this
 ;BIOS into a bigger ROM.
 ;Note that these refer to 16K banks, even in the case of using the ASCII8 mapper.
-ROM_BANK_0: equ 0
-ROM_BANK_1: equ 1
+config_const ROM_BANK_0,0
+config_const ROM_BANK_1,1
+

--- a/msx/constants.asm
+++ b/msx/constants.asm
@@ -16,6 +16,7 @@ KILBUF: equ 0156h
 
 CHRGTR: equ 4666h
 FRMEVL: equ 4C64h
+GETBYT: equ 521Ch
 FRMQNT: equ 542Fh
 FRESTR: equ 67D0h
 

--- a/msx/rookiefdd.asm
+++ b/msx/rookiefdd.asm
@@ -1,11 +1,13 @@
 ; Rookie Drive USB FDD BIOS
 ; By Konamiman, 2018
 ;
-; This is the main file. Assemble with:
-; sjasm rookiefdd.asm rookiefdd.rom
+; This is the main file, to be assembled with Nestor80 (https://github.com/Konamiman/Nestor80/):
 ;
-; See config.asm for customization options
-
+; N80 rookiefdd.asm rookiefdd.rom --direct-output-write
+;
+; There are configuration flags (see config.asm) that can be enabled by using --define-symbols, example:
+; 
+; N80 rookiefdd.asm rookiefdd.rom --direct-output-write --define-symbols INVERT_CTRL_KEY,DISABLE_OTHERS_BY_DEFAULT,IMPLEMENT_PANIC_BUTTON=0
 
 CALL_IX:   equ 7FD0h
 CALL_BANK: equ CALL_IX+2
@@ -69,3 +71,6 @@ DEFDPB_1:
     ds 7FFFh-$,0FFh
     db ROM_BANK_1
 
+    if USE_ROM_AS_DISK
+    incbin "GAME.DSK"
+    endif


### PR DESCRIPTION
This pull request implements improvements for floppy disk access:

- Adds proper adjustment of sector number for single-side disks. When a disk is identified as single sided, odd-numbered tracks must be skipped.
- However, some drives appear to perform the adjustment by themselves. In order to try to detect this (so we don't adjust again in code, ending up with an invalid sector number) a MODE SENSE command is sent and the "Number of heads" argument is checked.
- Added support for single sided disk formatting (quick and full).
- Added own `XFER` routine, used when the system one isn't active. This happens on games that boot on BASIC but then manually switch RAM in page 1.

There are also a couple of new features for debugging:

- `USE_ROM_AS_DISK` constant, allows embedding a DSK file in the ROM and use it instead of an actual disk.
- `_USBFDDMODE` command, to force the code to treat all disks as single sided or double sided.

Additionally, the code now requires [Nestor80](https://github.com/konamiman/Nestor80) to be assembled.