### PR TITLE
Fix: DSKCHG crashing in disk emulation mode in some games

### DIFF
--- a/msx/bank1/boot_menu.asm
+++ b/msx/bank1/boot_menu.asm
@@ -628,21 +628,22 @@ BM_DO_CONFIG_3:
 BM_DO_CONFIG_4:
     pop af
     or a
-    jr nz,BM_DO_CONFIG_ASK
+    jr nz,BM_DO_CONFIG_5
     set 1,(iy+BM_TEMP)
     ld hl,BM_CONFIG_UNSET_DEF_S
+    call PRINT
+    ld hl,BM_CONFIG_TWOCRLF_S
     call PRINT
 
     ;* Print "Enable/disable CAPS lit on file access"
 
-    ld hl,BM_CONFIG_TWOCRLF_S
-    call PRINT
+BM_DO_CONFIG_5:
     call DSK_TEST_CAPS_LIT
     or a
     ld hl,BM_CONFIG_ENABLE_8_S
-    jr z,BM_DO_CONFIG_5
+    jr z,BM_DO_CONFIG_6
     ld hl,BM_CONFIG_DISABLE_8_S
-BM_DO_CONFIG_5:
+BM_DO_CONFIG_6:
     call PRINT
     ld hl,BM_CONFIG_CAPS_LIT_S
     call PRINT

--- a/msx/bank1/dskio_dskchg.asm
+++ b/msx/bank1/dskio_dskchg.asm
@@ -1082,18 +1082,14 @@ _DSKCHG_IMPL_STDEV:
     cp 80h
     jp z,_DSKIO_IMPL_POPAF_RET_ERR  ;Storage device but no disk mounted
 
-    call MAYBE_CHANGE_DSK
+    ;For some reason calling MAYBE_CHANGE_DSK here sometimes causes a crash.
+    ;We'll just return "unknown" and let DSKIO handle the disk change.
 
     pop af
-    
-    call WK_GET_STORAGE_DEV_FLAGS
-    and 4
-    ld a,0
-    ld b,1  ;Unchanged
-    ret z
+
     call GETDPB_IMPL
     xor a
-    ld b,0FFh   ;Changed
+    ld b,0   ;Unknown
     ret
 
 


### PR DESCRIPTION
The exact cause of the crash is unknown, but it's at some point inside `MAYBE_CHANGE_DSK` when called from `DSKCHG` (it works fine when called from `DSKIO`).

I don't have much free time to research exactly what's/where's the bug, so this fix is more a workaround: now `MAYBE_CHANGE_DSK` is not called from within `DSCKCHG`, we always return a disk change status of "unknown" (remember, this is only in disk emulation mode, not when using actual floppies); a subsequent call to `DSKIO` will properly handle a possible disk change.

If someone wants to perform a more in-depth research of the bug and submit a pull request with a more appropriate fix I'll be glad to review and merge it.

This pull request fixes also a minor bug in the configuration screen of the boot menu: the "Enable/Disable CAPS lit on disk access" option wasn't being shown for directories, but it was still possible to press 8 and it had the expected effect (now the option is shown in directories too).

Closes #4.
