### PR TITLE
Fix: sector number was mistakenly adjusted for double sided disks too

### DIFF
--- a/msx/bank1/ch376.asm
+++ b/msx/bank1/ch376.asm
@@ -125,6 +125,11 @@ HW_TEST:
     ret
     endif
 
+    if USE_ROM_AS_DISK
+    or a
+    ret
+    endif
+
     ld a,34h
     call _HW_TEST_DO
     scf

--- a/msx/bank1/dskio_dskchg.asm
+++ b/msx/bank1/dskio_dskchg.asm
@@ -145,7 +145,7 @@ DSKIO_IMPL5:
 
     call CHECK_SAME_DRIVE
 
-    push af
+    push af ;Save drive and R/W flag
     cp 2
     jr nc,_DSKIO_ERR_PARAM
 
@@ -175,15 +175,6 @@ _DSKIO_OK_UNIT:
 
     ;=== DSKIO for floppy disk drives ===
 
-    ld a,b
-    pop bc
-    rrc c   ;Now C:7 = 0 to read, 1 to write
-    ld b,a
-
-    ;ld a,b
-    or a
-    ret z   ;Nothing to read
-
     push hl
     push de
     push bc
@@ -191,10 +182,22 @@ _DSKIO_OK_UNIT:
     pop bc
     pop de
     pop hl
-    ret c
+    jr nc,_DSKIO_TESTDISK_OK
+    pop hl  ;Drive and R/W flag
+    ret
 
+_DSKIO_TESTDISK_OK:
     call IS_SINGLE_SIDED
     call z,ADJUST_SECTOR_NUMBER
+
+    ld a,b
+    pop bc  ;Drive and R/W flag
+    rrc c   ;Now C:7 = 0 to read, 1 to write
+    ld b,a
+
+    ;ld a,b
+    or a
+    ret z   ;Nothing to read
 
     ld ix,-DSKIO_STACK_SPACE
     add ix,sp

--- a/msx/bank1/verbose_reset.asm
+++ b/msx/bank1/verbose_reset.asm
@@ -237,7 +237,7 @@ PRINT_ERROR:
 ; Strings
 
 ROOKIE_S:
-	db "Rookie Drive NestorBIOS v2.1",13,10
+	db "Rookie Drive NestorBIOS v2.1.1",13,10
 	db "(c) Konamiman 2025",13,10
 	db 13,10
     if USE_ROM_AS_DISK

--- a/msx/build.sh
+++ b/msx/build.sh
@@ -1,4 +1,4 @@
-VERSION=2.1
+VERSION=2.1.1
 SRC_PATH=$(dirname "$0")
 SRC_FILE=${SRC_PATH}/rookiefdd.asm
 DEST_DIR=${SRC_PATH}/bin


### PR DESCRIPTION
In v2.1 a sector number adjustment for single sided disks in DSKIO was introduced. However, by mistake the media ID passed to DSKIO was being corrupted before being used, and thus the sector number adjustmente was always being made; this rendered double sided disks unusable. This pull request fixes that.
